### PR TITLE
[Refactor] : 결제 페이지에 준회원이 아닌 경우 접근하지 못하도록 해요.

### DIFF
--- a/src/components/auth/guard/PaymentAccessGuard.tsx
+++ b/src/components/auth/guard/PaymentAccessGuard.tsx
@@ -1,0 +1,21 @@
+import { useQuery } from '@tanstack/react-query';
+import memberApi from '@/apis/member/memberApi';
+import { useNavigate } from 'react-router-dom';
+import RoutePath from '@/routes/routePath';
+
+const PaymentAccessGuard = () => {
+  const navigate = useNavigate();
+  const { data } = useQuery({
+    queryKey: ['member'],
+    queryFn: memberApi.GET_DASHBOARD
+  });
+
+  if (!data) {
+    return <div>로딩중..</div>;
+  }
+  if (data.member.role !== 'ASSOCIATE') {
+    navigate(RoutePath.Dashboard);
+  }
+};
+
+export default PaymentAccessGuard;

--- a/src/components/auth/guard/PaymentAccessGuard.tsx
+++ b/src/components/auth/guard/PaymentAccessGuard.tsx
@@ -1,24 +1,53 @@
 import { useQuery } from '@tanstack/react-query';
 import memberApi from '@/apis/member/memberApi';
-import { useNavigate } from 'react-router-dom';
+import { useState, useEffect } from 'react';
+import { Outlet, useNavigate } from 'react-router-dom';
 import RoutePath from '@/routes/routePath';
+import { toast } from 'react-toastify';
 
 const PaymentAccessGuard = () => {
+  const [redirect, setRedirect] = useState(false);
   const navigate = useNavigate();
   const { data } = useQuery({
     queryKey: ['member'],
     queryFn: memberApi.GET_DASHBOARD
   });
 
-  if (!data) {
-    return <div>로딩중..</div>;
-  }
+  useEffect(() => {
+    if (!data) return;
+
+    if (data.member.role !== 'ASSOCIATE') {
+      toast.error('준회원 조건을 충족해주세요.');
+      setRedirect(true);
+    }
+
+    if (!data.currentMembership) {
+      toast.error('정회원 지원 이후 학회비를 결제할 수 있어요.');
+      setRedirect(true);
+    }
+
+    if (!data.currentRecruitmentRound) {
+      toast.error('지금은 정회원 모집 기간이 아니에요.');
+      setRedirect(true);
+    }
+  }, []);
+
+  useEffect(() => {
+    if (redirect) {
+      navigate(RoutePath.Dashboard);
+    }
+  }, [redirect, navigate]);
+
+  if (!data) return;
+
   if (
     data.member.role !== 'ASSOCIATE' ||
-    !data.currentRecruitmentRound.period.open
+    !data.currentRecruitmentRound ||
+    !data.currentMembership
   ) {
     navigate(RoutePath.Dashboard);
-  }
+    return null;
+  } else return <Outlet />;
 };
 
 export default PaymentAccessGuard;

--- a/src/components/auth/guard/PaymentAccessGuard.tsx
+++ b/src/components/auth/guard/PaymentAccessGuard.tsx
@@ -13,7 +13,10 @@ const PaymentAccessGuard = () => {
   if (!data) {
     return <div>로딩중..</div>;
   }
-  if (data.member.role !== 'ASSOCIATE') {
+  if (
+    data.member.role !== 'ASSOCIATE' ||
+    !data.currentRecruitmentRound.period.open
+  ) {
     navigate(RoutePath.Dashboard);
   }
 };

--- a/src/components/auth/guard/PaymentAccessGuard.tsx
+++ b/src/components/auth/guard/PaymentAccessGuard.tsx
@@ -4,11 +4,12 @@ import { useState, useEffect } from 'react';
 import { Outlet, useNavigate } from 'react-router-dom';
 import RoutePath from '@/routes/routePath';
 import { toast } from 'react-toastify';
+import LoadingSpinner from '@/components/common/LoadingSpinner';
 
 const PaymentAccessGuard = () => {
   const [redirect, setRedirect] = useState(false);
   const navigate = useNavigate();
-  const { data } = useQuery({
+  const { data, isLoading } = useQuery({
     queryKey: ['member'],
     queryFn: memberApi.GET_DASHBOARD
   });
@@ -37,6 +38,10 @@ const PaymentAccessGuard = () => {
       navigate(RoutePath.Dashboard);
     }
   }, [redirect, navigate]);
+
+  if (isLoading) {
+    return <LoadingSpinner />;
+  }
 
   if (!data) return;
 

--- a/src/components/auth/guard/PaymentSuccessAccessGuard.tsx
+++ b/src/components/auth/guard/PaymentSuccessAccessGuard.tsx
@@ -1,0 +1,49 @@
+import { useQuery } from '@tanstack/react-query';
+import memberApi from '@/apis/member/memberApi';
+import { useState, useEffect } from 'react';
+import { Outlet, useNavigate } from 'react-router-dom';
+import RoutePath from '@/routes/routePath';
+import { toast } from 'react-toastify';
+import LoadingSpinner from '@/components/common/LoadingSpinner';
+
+const PaymentSuccessAccessGuard = () => {
+  const [redirect, setRedirect] = useState(false);
+  const navigate = useNavigate();
+  const { data, isLoading } = useQuery({
+    queryKey: ['member'],
+    queryFn: memberApi.GET_DASHBOARD
+  });
+
+  useEffect(() => {
+    if (!data) return;
+
+    if (data.member.role !== 'REGULAR') {
+      toast.error('토스페이먼츠 결제를 완료해주세요.');
+      setRedirect(true);
+    }
+
+    if (!data.currentRecruitmentRound) {
+      toast.error('지금은 정회원 모집 기간이 아니에요.');
+      setRedirect(true);
+    }
+  }, []);
+
+  useEffect(() => {
+    if (redirect) {
+      navigate(RoutePath.Dashboard);
+    }
+  }, [redirect, navigate]);
+
+  if (isLoading) {
+    return <LoadingSpinner />;
+  }
+
+  if (!data) return;
+
+  if (data.member.role !== 'REGULAR' || !data.currentRecruitmentRound) {
+    navigate(RoutePath.Dashboard);
+    return null;
+  } else return <Outlet />;
+};
+
+export default PaymentSuccessAccessGuard;

--- a/src/routes/index.tsx
+++ b/src/routes/index.tsx
@@ -2,6 +2,7 @@ import App from '@/App';
 import * as Sentry from '@sentry/react';
 import RoutePath from '@/routes/routePath';
 import { RouterProvider, createBrowserRouter } from 'react-router-dom';
+import PaymentSuccessAccessGuard from '@/components/auth/guard/PaymentSuccessAccessGuard';
 import Layout from '@/components/layout/Layout';
 import {
   MypageAccessGuard,
@@ -128,11 +129,13 @@ const router = sentryCreateBrowserRouter([
       },
       {
         path: RoutePath.PaymentsFail,
+        element: <AuthAccessGuard />,
         children: [{ index: true, element: <PaymentsFail /> }]
       },
       {
         path: RoutePath.PaymentsSuccess,
-        element: <PaymentsSuccess />
+        element: <PaymentSuccessAccessGuard />,
+        children: [{ index: true, element: <PaymentsSuccess /> }]
       },
       // Todo: 404 Not found page
       { path: '*', element: <Text>not found page</Text> }

--- a/src/routes/index.tsx
+++ b/src/routes/index.tsx
@@ -31,6 +31,7 @@ import {
 import { DicordConnect } from '@/pages/DiscordConnect';
 import { DiscordGuide } from '@/pages/DiscordGuide';
 import { Suspense } from 'react';
+import PaymentAccessGuard from '@/components/auth/guard/PaymentAccessGuard';
 
 const sentryCreateBrowserRouter =
   Sentry.wrapCreateBrowserRouter(createBrowserRouter);
@@ -122,11 +123,12 @@ const router = sentryCreateBrowserRouter([
       },
       {
         path: RoutePath.PaymentsCheckout,
-        element: <PaymentsCheckout />
+        element: <PaymentAccessGuard />,
+        children: [{ index: true, element: <PaymentsCheckout /> }]
       },
       {
         path: RoutePath.PaymentsFail,
-        element: <PaymentsFail />
+        children: [{ index: true, element: <PaymentsFail /> }]
       },
       {
         path: RoutePath.PaymentsSuccess,


### PR DESCRIPTION
## 🎉 변경 사항
현재 토스페이먼츠 결제 위젯에 누구나 링크만 있으면 접근할 수 있는 것 같아서 가드 컴포넌트를 만들었어요.
[접근할 수 있는 경우]
- 준회원일 때
- 모집 기간이 열려 있을때

접근하지 못하는 상태일 때 넘어가면 자동으로 대시보드로 넘어갑니다.

+) 토스트로 안내를 추가적으로 하는 것이 좋을까요?
ex. 게스트일때 => 준회원 조건을 모두 충족한 이후 회비를 납부해주세요.
ex. 정회원일때 => 이미 회비 납부를 완료했어요.

