### PR TITLE
[Feature]: 와우 디자인 시스템의 RainbowSpinner를 적용해요

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,7 +26,6 @@
     "react-dom": "^18.2.0",
     "react-hook-form": "^7.50.1",
     "react-router-dom": "^6.22.1",
-    "react-spinners": "^0.13.8",
     "react-toastify": "^10.0.4",
     "wowds-icons": "^0.1.0",
     "wowds-tokens": "^0.0.9",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -44,9 +44,6 @@ dependencies:
   react-router-dom:
     specifier: ^6.22.1
     version: 6.22.1(react-dom@18.2.0)(react@18.2.0)
-  react-spinners:
-    specifier: ^0.13.8
-    version: 0.13.8(react-dom@18.2.0)(react@18.2.0)
   react-toastify:
     specifier: ^10.0.4
     version: 10.0.4(react-dom@18.2.0)(react@18.2.0)
@@ -8897,16 +8894,6 @@ packages:
     dependencies:
       '@remix-run/router': 1.15.1
       react: 18.2.0
-    dev: false
-
-  /react-spinners@0.13.8(react-dom@18.2.0)(react@18.2.0):
-    resolution: {integrity: sha512-3e+k56lUkPj0vb5NDXPVFAOkPC//XyhKPJjvcGjyMNPWsBKpplfeyialP74G7H7+It7KzhtET+MvGqbKgAqpZA==}
-    peerDependencies:
-      react: ^16.0.0 || ^17.0.0 || ^18.0.0
-      react-dom: ^16.0.0 || ^17.0.0 || ^18.0.0
-    dependencies:
-      react: 18.2.0
-      react-dom: 18.2.0(react@18.2.0)
     dev: false
 
   /react-style-singleton@2.2.1(@types/react@18.2.58)(react@18.2.0):

--- a/src/components/common/LoadingSpinner.tsx
+++ b/src/components/common/LoadingSpinner.tsx
@@ -1,0 +1,31 @@
+import RainbowSpinner from 'wowds-ui/RainbowSpinner';
+import { media } from '@/styles';
+import GlobalSize from '@/constants/globalSize';
+import { Flex } from './Wrapper';
+import { color } from 'wowds-tokens';
+import styled from '@emotion/styled';
+
+const LoadingSpinner = () => {
+  return (
+    <Wrapper justify="center" align="center">
+      <RainbowSpinner width={60} height={60} />
+    </Wrapper>
+  );
+};
+
+export default LoadingSpinner;
+
+const Wrapper = styled(Flex)`
+  min-height: 100vh;
+  position: fixed;
+  top: 0;
+  z-index: 999;
+  width: ${GlobalSize.width};
+  margin: 0px -16px;
+  padding: 0px 16px;
+  gap: 40px;
+  background-color: ${color.blackOpacity40};
+  ${media.mobile} {
+    width: 100vw;
+  }
+`;

--- a/src/pages/Dashboard.tsx
+++ b/src/pages/Dashboard.tsx
@@ -12,6 +12,7 @@ import memberApi from '@/apis/member/memberApi';
 import GlobalSize from '@/constants/globalSize';
 import JoinStatus from '@/components/myPage/JoinStatus';
 import useBottomSheet from '@/hooks/common/useBottomSheet';
+import LoadingSpinner from '@/components/common/LoadingSpinner';
 
 export const Dashboard = () => {
   const { isOpen } = useBottomSheet();
@@ -20,9 +21,12 @@ export const Dashboard = () => {
     queryFn: memberApi.GET_DASHBOARD
   });
 
-  //TODO: 추후 로딩 스피너 삽입할 것
   if (!data) {
-    return <div> 로딩중 ...</div>;
+    return (
+      <Wrapper direction="column" justify="flex-start">
+        <LoadingSpinner />
+      </Wrapper>
+    );
   }
 
   const { member, currentRecruitmentRound, currentMembership } = data;

--- a/src/pages/StudentVerification.tsx
+++ b/src/pages/StudentVerification.tsx
@@ -10,6 +10,7 @@ import { Controller } from 'react-hook-form';
 import { useEffect, useState } from 'react';
 import { media } from '@/styles';
 import GlobalSize from '@/constants/globalSize';
+import LoadingSpinner from '@/components/common/LoadingSpinner';
 
 /** 재학생 인증 페이지 */
 export const StudentVerification = () => {
@@ -39,12 +40,9 @@ export const StudentVerification = () => {
     onSubmit();
   };
 
-  if (isPending) {
-    return <div>로딩중입니다...</div>;
-  }
-
   return (
     <Wrapper direction="column" justify="flex-start" gap="lg">
+      {isPending && <LoadingSpinner />}
       <TextContainer>
         <Text typo="h1" style={{ marginBottom: '12px' }}>
           재학생 인증하기

--- a/src/pages/redirect/StudentVerificationServerRedirect.tsx
+++ b/src/pages/redirect/StudentVerificationServerRedirect.tsx
@@ -7,9 +7,9 @@ import { media } from '@/styles';
 import styled from '@emotion/styled';
 import { css } from '@emotion/react';
 import { useNavigate, useSearchParams } from 'react-router-dom';
-import { PulseLoader } from 'react-spinners';
 import RoutePath from '@/routes/routePath';
 import { useLayoutEffect } from 'react';
+import LoadingSpinner from '@/components/common/LoadingSpinner';
 
 export const StudentVerificationServerRedirect = () => {
   const [searchParams] = useSearchParams();
@@ -26,7 +26,7 @@ export const StudentVerificationServerRedirect = () => {
   return (
     <Wrapper direction="column">
       {isPending ? (
-        <PulseLoader loading={isPending} />
+        <LoadingSpinner />
       ) : (
         <Container direction="column">
           <Text


### PR DESCRIPTION
## 🎉 변경 사항
현재 와우 온보딩 서비스에 Spinner가 존재하지 않아서 로딩 중 상태를 구별하기가 어려웠는데, 이를 방지하기 위해 Spinner 공통 컴포넌트를 생성하여 넣어두었습니다~ 
기존에 사용하고 있던 react-spinner 컴포넌트 패키지는 제거했습니다. 

![로딩스피너](https://github.com/user-attachments/assets/e51ed8bc-7a9b-420e-8aca-d74f467eeae0)
