### PR TITLE
[Refactor]: 마이너 UI 이슈 수정

### DIFF
--- a/src/components/layout/Layout.tsx
+++ b/src/components/layout/Layout.tsx
@@ -4,12 +4,18 @@ import { media } from '@/styles';
 import { color } from 'wowds-tokens';
 import Header from '@/components/layout/Header';
 import Footer from '@/components/layout/Footer';
-
-import { Outlet } from 'react-router-dom';
+import { useLayoutEffect } from 'react';
+import { Outlet, useLocation } from 'react-router-dom';
 import GlobalSize from '@/constants/globalSize';
 import ApiErrorBoundary from '@/components/ApiErrorBoundary';
 
 const Layout = () => {
+  const location = useLocation();
+
+  useLayoutEffect(() => {
+    window.scrollTo(0, 0);
+  }, [location]);
+
   return (
     <ApiErrorBoundary>
       <Container>

--- a/src/pages/SignUp.tsx
+++ b/src/pages/SignUp.tsx
@@ -188,6 +188,7 @@ export const SignUp = () => {
             render={({ field, fieldState }) => (
               <TextFieldWrapper>
                 <TextField
+                  style={{ minWidth: '100%' }}
                   label="이메일 주소"
                   error={fieldState.invalid}
                   ref={field.ref}


### PR DESCRIPTION
## 🎉 변경 사항
- 이메일을 입력할 때 가로 [TextField가 깨지는 현상](https://www.notion.so/QA-cd51a8b991304f37a65e0f0e6a98a21f?pvs=4)을 개선해요.
- 대시보드에서 스크롤을 내린 채로 다음 페이지로 이동하면 해당 스크롤이 고정되어서 글자들이 짤려 보이는 현상을 개선해요.
![스크롤](https://github.com/user-attachments/assets/26eafda6-4498-44f4-8977-1e50e8bdb2a2)

아마 Footer가 추가되고 나서 세로 스크롤 영역이 늘어나면서 생긴 현상 같아요 (기존에는 height를 화면 크기에 맞춰서 고려하지 않았던 문제엿는 듯)

