### PR TITLE
[Fix] 토스페이먼츠 결제성공 페이지 가드 임시삭제

### DIFF
--- a/src/hooks/zustand/useProduct.ts
+++ b/src/hooks/zustand/useProduct.ts
@@ -19,7 +19,8 @@ export const useProductStore = create<ProductStore>((set) => ({
   setDiscount: (newDiscount, couponId) =>
     set((state) => ({
       discount: newDiscount,
-      totalAmount: state.amount - newDiscount,
+      totalAmount:
+        state.amount - newDiscount < 0 ? 0 : state.amount - newDiscount,
       issuedCouponId: couponId
     }))
 }));

--- a/src/routes/index.tsx
+++ b/src/routes/index.tsx
@@ -2,7 +2,6 @@ import App from '@/App';
 import * as Sentry from '@sentry/react';
 import RoutePath from '@/routes/routePath';
 import { RouterProvider, createBrowserRouter } from 'react-router-dom';
-import PaymentSuccessAccessGuard from '@/components/auth/guard/PaymentSuccessAccessGuard';
 import Layout from '@/components/layout/Layout';
 import AuthAccessGuard from '@/components/auth/guard/AuthAccessGuard';
 import { Text } from '@/components/common/Wrapper';

--- a/src/routes/index.tsx
+++ b/src/routes/index.tsx
@@ -108,8 +108,7 @@ const router = sentryCreateBrowserRouter([
       },
       {
         path: RoutePath.PaymentsSuccess,
-        element: <PaymentSuccessAccessGuard />,
-        children: [{ index: true, element: <PaymentsSuccess /> }]
+        element: <PaymentsSuccess />
       },
       // Todo: 404 Not found page
       { path: '*', element: <Text>not found page</Text> }


### PR DESCRIPTION
## 🎉 변경 사항
- 결제성공 페이지의 가드를 임시로 삭제합니다.
- 전체 금액이 0 미만이 되었을 때 금액을 0으로 설정합니다.

## 🚩 관련 이슈

### 🙏 여기는 꼭 봐주세요!
