### PR TITLE
[Fix] 정회원 지원 및 회비 결제 플로우 개선

### DIFF
--- a/src/components/bottomsheet/JoinRegularMemberBottomSheet.tsx
+++ b/src/components/bottomsheet/JoinRegularMemberBottomSheet.tsx
@@ -1,11 +1,8 @@
-import {
-  CurrentMembershipType,
-  CurrentRecruitmentType
-} from '@/apis/member/memberType';
+import { CurrentRecruitmentType } from '@/apis/member/memberType';
 import BottomSheet from '@/components/common/BottomSheet';
 import { Flex, Space, Text } from '@/components/common/Wrapper';
 import CustomBox from '@/components/myPage/CustomBox';
-import useBottomSheet from '@/hooks/common/useBottomSheet';
+import useJoinRegularMember from '@/hooks/mutation/useJoinRegularMember';
 import RoutePath from '@/routes/routePath';
 import {
   convertRecruitmentName,
@@ -17,13 +14,11 @@ import { color } from 'wowds-tokens';
 import Button from 'wowds-ui/Button';
 
 const JoinRegularMemberBottomSheet = ({
-  currentRecruitment,
-  currentMembership
+  currentRecruitment
 }: {
   currentRecruitment: CurrentRecruitmentType;
-  currentMembership: CurrentMembershipType | null;
 }) => {
-  const { onApply, handleBottomSheet } = useBottomSheet();
+  const { joinRegularMember } = useJoinRegularMember();
   const bottomSheetTitle = convertRecruitmentName(
     currentRecruitment.name,
     currentRecruitment.roundTypeValue
@@ -89,17 +84,10 @@ const JoinRegularMemberBottomSheet = ({
           {recruitmentPeriod}
         </Text>
         <Button
-          // disabled={currentMembership ? true : false}
           onClick={() => {
-            // joinRegularMember(currentRecruitment.recruitmentId);
-            if (onApply) {
-              onApply();
-            }
-            handleBottomSheet();
+            joinRegularMember(currentRecruitment.recruitmentId);
           }}>
-          {currentMembership
-            ? '정회원 가입 조건을 완료해주세요.'
-            : '지원하러 가기'}
+          {'지원하러 가기'}
         </Button>
       </BottomSheetContent>
     </BottomSheet>

--- a/src/components/myPage/JoinRegularMember.tsx
+++ b/src/components/myPage/JoinRegularMember.tsx
@@ -1,4 +1,7 @@
-import { CurrentRecruitmentType } from '@/apis/member/memberType';
+import {
+  CurrentMembershipType,
+  CurrentRecruitmentType
+} from '@/apis/member/memberType';
 import { Flex, Text } from '@/components/common/Wrapper';
 import useBottomSheet from '@/hooks/common/useBottomSheet';
 import RoutePath from '@/routes/routePath';
@@ -8,7 +11,6 @@ import {
   convertRecruitmentName,
   convertRecruitmentPeriod
 } from '@/utils/mypage/recruitmentNameFormat';
-import { useState } from 'react';
 import { useNavigate } from 'react-router-dom';
 import CustomBox from './CustomBox';
 import StatusBadge from './StatusBadge';
@@ -16,14 +18,15 @@ import StatusBadge from './StatusBadge';
 const JoinRegularMember = ({
   role,
   paymentStatus,
+  currentMembership,
   currentRecruitment
 }: {
   role: UserRoleType;
   paymentStatus?: Status;
+  currentMembership: CurrentMembershipType | null;
   currentRecruitment: CurrentRecruitmentType;
 }) => {
   const navigate = useNavigate();
-  const [isApplying, setIsApplying] = useState(false);
   const { handleBottomSheet } = useBottomSheet();
   const handleClickRoute = () => {
     navigate(RoutePath.PaymentsCheckout);
@@ -53,7 +56,7 @@ const JoinRegularMember = ({
             }
             status="success"
           />
-        ) : isApplying ? (
+        ) : currentMembership ? (
           <CustomBox
             text={'이번 학기 회비를 납부해주세요.'}
             variant={'arrow'}
@@ -85,7 +88,7 @@ const JoinRegularMember = ({
             }
             variant={'arrow'}
             status="error"
-            onClick={() => handleBottomSheet(() => setIsApplying(true))}
+            onClick={() => handleBottomSheet()}
           />
         )
       ) : (

--- a/src/components/payments/PaymentItemBox.tsx
+++ b/src/components/payments/PaymentItemBox.tsx
@@ -14,9 +14,11 @@ export const PaymentItemBox = () => {
   });
 
   useEffect(() => {
-    setName('만원');
-    setAmount(10000);
-  }, [setAmount, setName]);
+    if (member?.currentRecruitmentRound) {
+      setName(member.currentRecruitmentRound.feeName);
+      setAmount(member.currentRecruitmentRound.fee);
+    }
+  }, [member, setAmount, setName]);
 
   return (
     <>

--- a/src/components/payments/PaymentsWidget.tsx
+++ b/src/components/payments/PaymentsWidget.tsx
@@ -31,7 +31,7 @@ export function PaymentsWidget() {
 
   const { name, amount, discount, issuedCouponId, totalAmount } = useProduct();
 
-  const { postPrevOrder } = usePostPrevOrder(totalAmount);
+  const { postPrevOrderAsync } = usePostPrevOrder(totalAmount);
 
   const [ready, setReady] = useState(false);
 
@@ -84,7 +84,7 @@ export function PaymentsWidget() {
     try {
       if (!dashboard) throw new Error();
 
-      postPrevOrder({
+      await postPrevOrderAsync({
         orderNanoId: id,
         membershipId: dashboard.currentMembership.membershipId,
         issuedCouponId: issuedCouponId,

--- a/src/components/provider/BottomSheetProvider.tsx
+++ b/src/components/provider/BottomSheetProvider.tsx
@@ -3,17 +3,12 @@ import { ReactNode, useCallback, useState } from 'react';
 
 const BottomSheetProvider = ({ children }: { children: ReactNode }) => {
   const [isOpen, setIsOpen] = useState(false);
-  const [onApply, setOnApply] = useState<(() => void) | null>(null);
-
-  const handleBottomSheet = useCallback((applyCallback?: () => void) => {
+  const handleBottomSheet = useCallback(() => {
     setIsOpen((prev) => !prev);
-    if (applyCallback) {
-      setOnApply(() => applyCallback);
-    }
   }, []);
 
   return (
-    <BottomSheetContext.Provider value={{ isOpen, handleBottomSheet, onApply }}>
+    <BottomSheetContext.Provider value={{ isOpen, handleBottomSheet }}>
       {children}
     </BottomSheetContext.Provider>
   );

--- a/src/context/BottomSheetContext.tsx
+++ b/src/context/BottomSheetContext.tsx
@@ -2,6 +2,5 @@ import { createContext } from 'react';
 
 export const BottomSheetContext = createContext({
   isOpen: false,
-  handleBottomSheet: (_applyCallback?: () => void) => {},
-  onApply: null as (() => void) | null
+  handleBottomSheet: () => {}
 });

--- a/src/hooks/common/useBottomSheet.tsx
+++ b/src/hooks/common/useBottomSheet.tsx
@@ -1,14 +1,14 @@
 import BottomSheet from '@/components/common/BottomSheet';
-import { useContext, ReactNode } from 'react';
 import { BottomSheetContext } from '@/context/BottomSheetContext';
+import { ReactNode, useContext } from 'react';
 
 const useBottomSheet = () => {
-  const { isOpen, handleBottomSheet, onApply } = useContext(BottomSheetContext);
+  const { isOpen, handleBottomSheet } = useContext(BottomSheetContext);
 
   const BottomSheetElement = ({ children }: { children: ReactNode }) => {
     return <BottomSheet>{children}</BottomSheet>;
   };
-  return { isOpen, BottomSheetElement, handleBottomSheet, onApply };
+  return { isOpen, BottomSheetElement, handleBottomSheet };
 };
 
 export default useBottomSheet;

--- a/src/hooks/mutation/usePostOrder.ts
+++ b/src/hooks/mutation/usePostOrder.ts
@@ -1,16 +1,12 @@
 import { useMutation } from '@tanstack/react-query';
-import { useNavigate } from 'react-router-dom';
 import ordersApi from '@/apis/orders/ordersApi';
-import RoutePath from '@/routes/routePath';
 
 const usePostOrder = () => {
-  const navigate = useNavigate();
-  const { mutate: postOrder, ...rest } = useMutation({
-    mutationFn: ordersApi.POST_ORDER,
-    onError: () => navigate(RoutePath.PaymentsFail)
+  const { mutate: postOrder, mutateAsync: postOrderAsync, ...rest } = useMutation({
+    mutationFn: ordersApi.POST_ORDER
   });
 
-  return { postOrder, ...rest };
+  return { postOrder, postOrderAsync, ...rest };
 };
 
 export default usePostOrder;

--- a/src/hooks/mutation/usePostPrevOrder.ts
+++ b/src/hooks/mutation/usePostPrevOrder.ts
@@ -8,7 +8,11 @@ import { toast } from 'react-toastify';
 const usePostPrevOrder = (amount: number) => {
   const navigate = useNavigate();
 
-  const { mutate: postPrevOrder, ...rest } = useMutation({
+  const {
+    mutate: postPrevOrder,
+    mutateAsync: postPrevOrderAsync,
+    ...rest
+  } = useMutation({
     onMutate: () => {
       if (!amount) toast('결제를 실패했어요. 문제가 지속되면 문의해주세요.');
     },
@@ -16,7 +20,7 @@ const usePostPrevOrder = (amount: number) => {
     onError: () => navigate(RoutePath.PaymentsCheckout)
   });
 
-  return { postPrevOrder, ...rest };
+  return { postPrevOrder, postPrevOrderAsync, ...rest };
 };
 
 export default usePostPrevOrder;

--- a/src/hooks/zustand/useProduct.ts
+++ b/src/hooks/zustand/useProduct.ts
@@ -19,7 +19,11 @@ export const useProductStore = create<ProductStore>((set) => ({
   discount: 0,
   issuedCouponId: null,
   setName: (name) => set({ name }),
-  setAmount: (amount) => set({ amount }),
+  setAmount: (amount) =>
+    set((state) => ({
+      amount,
+      totalAmount: amount - state.discount < 0 ? 0 : amount - state.discount
+    })),
   setDiscount: (newDiscount, couponId) =>
     set((state) => ({
       discount: newDiscount,

--- a/src/pages/Dashboard.tsx
+++ b/src/pages/Dashboard.tsx
@@ -44,6 +44,7 @@ export const Dashboard = () => {
               <Space height={40} />
               <JoinRegularMember
                 role={member.role}
+                currentMembership={currentMembership}
                 currentRecruitment={currentRecruitmentRound}
                 paymentStatus={
                   currentMembership?.regularRequirement.paymentStatus
@@ -61,7 +62,6 @@ export const Dashboard = () => {
       </Wrapper>
       {isOpen && (
         <JoinRegularMemberBottomSheet
-          currentMembership={currentMembership}
           currentRecruitment={currentRecruitmentRound}
         />
       )}

--- a/src/pages/PaymentsSuccess.tsx
+++ b/src/pages/PaymentsSuccess.tsx
@@ -9,44 +9,55 @@ import Button from 'wowds-ui/Button';
 import GlobalSize from '@/constants/globalSize';
 import usePostOrder from '@/hooks/mutation/usePostOrder';
 import RoutePath from '@/routes/routePath';
-import { useEffect } from 'react';
+import { useEffect, useRef } from 'react';
 import { color } from 'wowds-tokens';
+import axios from 'axios';
 
 export function PaymentsSuccess() {
   const navigate = useNavigate();
   const queryClient = useQueryClient();
   const [searchParams] = useSearchParams();
+  const isCalledRef = useRef(false);
 
-  const { postOrder } = usePostOrder();
-
-  const confirm = async () => {
-    const requestData = {
-      orderId: searchParams.get('orderId'),
-      amount: searchParams.get('amount'),
-      paymentType: searchParams.get('paymentType'),
-      paymentKey: searchParams.get('paymentKey')
-    };
-
-    if (!requestData.orderId || !requestData.amount || !requestData.paymentKey)
-      throw new Error('Invalid payment information');
-
-    postOrder({
-      paymentKey: requestData.paymentKey,
-      orderNanoId: requestData.orderId,
-      amount: +requestData.amount
-    });
-  };
+  const { postOrderAsync } = usePostOrder();
 
   useEffect(() => {
+    if (isCalledRef.current) return;
+    isCalledRef.current = true;
+
     const executeConfirm = async () => {
+      const requestData = {
+        orderId: searchParams.get('orderId'),
+        amount: searchParams.get('amount'),
+        paymentKey: searchParams.get('paymentKey')
+      };
+
+      if (
+        !requestData.orderId ||
+        !requestData.amount ||
+        !requestData.paymentKey
+      ) {
+        navigate(RoutePath.PaymentsFail);
+        return;
+      }
+
       try {
-        await confirm();
+        await postOrderAsync({
+          paymentKey: requestData.paymentKey,
+          orderNanoId: requestData.orderId,
+          amount: +requestData.amount
+        });
       } catch (error) {
+        // 409 Conflict는 이미 처리된 요청이므로 성공으로 간주
+        if (axios.isAxiosError(error) && error.response?.status === 409) {
+          return;
+        }
         navigate(RoutePath.PaymentsFail);
       }
     };
+
     executeConfirm();
-  }, [searchParams]);
+  }, []);
 
   return (
     <Wrapper direction="column" justify="space-between">


### PR DESCRIPTION
## 🎉 변경 사항

정회원 지원 (JoinRegularMemberBottomSheet)
- 바텀시트가 API 성공 후에만 닫히도록 수정
- 불필요한 중복 `handleBottomSheet()` 호출 제거

결제 완료 (PaymentsSuccess)
- `useRef`로 StrictMode 중복 호출 방지
- 409 Conflict 에러 처리 (이미 처리된 결제는 성공으로 간주)
- 파라미터 누락 시 실패 페이지로 리다이렉트

결제 위젯 (PaymentsWidget)
- 선주문 API를 `mutateAsync`로 변경하여 await 처리

상태 관리 (useProduct)
- `setAmount` 시 `totalAmount` 자동 동기화

결제 항목 (PaymentItemBox)
- 하드코딩된 값 대신 실제 회비 정보 사용

## 🚩 관련 이슈

### 🙏 여기는 꼭 봐주세요!


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

# 릴리스 노트

* **New Features**
  * 이메일 인증 흐름 추가
  * 계정 정보 조회 및 GitHub 연동 정보 표시 기능
  * 학번 중복 확인 기능
  * 동적 캐루셀 및 모달 컴포넌트 추가
  * FAQ 페이지 신설

* **Style**
  * 브랜딩 업데이트 (GDGoC Hongik → GDG Hongik Univ.)
  * UI 레이아웃 및 컴포넌트 개선
  * 외부 링크 업데이트

* **Refactor**
  * 라우팅 및 내비게이션 로직 개선
  * 컴포넌트 상태 관리 및 구조 최적화

<!-- end of auto-generated comment: release notes by coderabbit.ai -->