### PR TITLE
[Style] 이메일 인증 정렬

### DIFF
--- a/src/pages/redirect/EmailVerificationServerRedirect.tsx
+++ b/src/pages/redirect/EmailVerificationServerRedirect.tsx
@@ -39,11 +39,8 @@ export const EmailVerificationServerRedirect = () => {
       {isPending ? (
         <LoadingSpinner />
       ) : (
-        <Container
-          direction="column"
-          align="flex-start"
-          justify="space-between">
-          <Flex direction="column" align="flex-start" gap="xl">
+        <Container direction="column" align="center" justify="space-between">
+          <Flex direction="column" align="center" gap="xl">
             <Text
               typo="h1"
               css={css`

--- a/src/pages/redirect/EmailVerificationServerRedirect.tsx
+++ b/src/pages/redirect/EmailVerificationServerRedirect.tsx
@@ -3,6 +3,7 @@ import { Flex, Text } from '@/components/common/Wrapper';
 import { useVerifyEmail } from '@/hooks/mutation';
 import RoutePath from '@/routes/routePath';
 import { css } from '@emotion/react';
+import { media } from '@/styles';
 import styled from '@emotion/styled';
 import { useLayoutEffect, useState } from 'react';
 import { useNavigate, useSearchParams } from 'react-router-dom';
@@ -39,12 +40,22 @@ export const EmailVerificationServerRedirect = () => {
       {isPending ? (
         <LoadingSpinner />
       ) : (
-        <Container direction="column" align="center" justify="space-between">
-          <Flex direction="column" align="center" gap="xl">
+        <Container direction="column" justify="space-between">
+          <Flex
+            direction="column"
+            gap="xl"
+            align-items="flex-start"
+            css={css`
+              ${media.pc}
+              align-items: center;
+            `}>
             <Text
               typo="h1"
               css={css`
                 margin-top: 40px;
+                ${media.pc} {
+                  align-items: center;
+                }
               `}>
               {isSuccess ? '본인 인증 성공' : '본인 인증 실패'}
             </Text>

--- a/src/pages/redirect/EmailVerificationServerRedirect.tsx
+++ b/src/pages/redirect/EmailVerificationServerRedirect.tsx
@@ -44,7 +44,7 @@ export const EmailVerificationServerRedirect = () => {
           <Flex
             direction="column"
             gap="xl"
-            align-items="flex-start"
+            align="flex-start"
             css={css`
               ${media.pc}
               align-items: center;

--- a/src/pages/redirect/StudentVerificationServerRedirect.tsx
+++ b/src/pages/redirect/StudentVerificationServerRedirect.tsx
@@ -2,6 +2,7 @@ import LoadingSpinner from '@/components/common/LoadingSpinner';
 import { Flex, Text } from '@/components/common/Wrapper';
 import { useVerifyStudentEmail } from '@/hooks/mutation';
 import { css } from '@emotion/react';
+import { media } from '@/styles';
 import styled from '@emotion/styled';
 import { useLayoutEffect } from 'react';
 import { useSearchParams } from 'react-router-dom';
@@ -21,12 +22,15 @@ export const StudentVerificationServerRedirect = () => {
       {isPending ? (
         <LoadingSpinner />
       ) : (
-        <Container direction="column" align="center">
+        <Container direction="column" align-items="flex-start">
           <Text
             typo="h1"
             css={css`
               margin-bottom: 20px;
               margin-top: 40px;
+              ${media.pc} {
+                align-items: center;
+              }
             `}>
             {isSuccess ? '재학생 인증 성공' : '재학생 인증 실패'}
           </Text>

--- a/src/pages/redirect/StudentVerificationServerRedirect.tsx
+++ b/src/pages/redirect/StudentVerificationServerRedirect.tsx
@@ -22,28 +22,38 @@ export const StudentVerificationServerRedirect = () => {
       {isPending ? (
         <LoadingSpinner />
       ) : (
-        <Container direction="column" align-items="flex-start">
-          <Text
-            typo="h1"
+        <Container direction="column" align="flex-start">
+          <Flex
+            direction="column"
+            gap="xl"
+            align="flex-start"
             css={css`
-              margin-bottom: 20px;
-              margin-top: 40px;
               ${media.pc} {
                 align-items: center;
               }
             `}>
-            {isSuccess ? '재학생 인증 성공' : '재학생 인증 실패'}
-          </Text>
-          <TextContainer>
-            {isSuccess ? (
-              <Text typo="body1">홍익대학교 재학생 인증에 성공했어요.</Text>
-            ) : (
-              <Text typo="body1">
-                유효하지 않거나 만료된 인증코드예요. 원래 페이지로 돌아가서 메일
-                재전송 버튼을 눌러주세요.
-              </Text>
-            )}
-          </TextContainer>
+            <Text
+              typo="h1"
+              css={css`
+                margin-bottom: 20px;
+                margin-top: 40px;
+                ${media.pc} {
+                  align-items: center;
+                }
+              `}>
+              {isSuccess ? '재학생 인증 성공' : '재학생 인증 실패'}
+            </Text>
+            <TextContainer>
+              {isSuccess ? (
+                <Text typo="body1">홍익대학교 재학생 인증에 성공했어요.</Text>
+              ) : (
+                <Text typo="body1">
+                  유효하지 않거나 만료된 인증코드예요. 원래 페이지로 돌아가서
+                  메일 재전송 버튼을 눌러주세요.
+                </Text>
+              )}
+            </TextContainer>
+          </Flex>
         </Container>
       )}
     </Wrapper>

--- a/src/pages/redirect/StudentVerificationServerRedirect.tsx
+++ b/src/pages/redirect/StudentVerificationServerRedirect.tsx
@@ -21,7 +21,7 @@ export const StudentVerificationServerRedirect = () => {
       {isPending ? (
         <LoadingSpinner />
       ) : (
-        <Container direction="column" align="flex-start">
+        <Container direction="column" align="center">
           <Text
             typo="h1"
             css={css`


### PR DESCRIPTION
## 🎉 변경 사항
이메일 인증 중앙 정렬로 변경

## 🚩 관련 이슈
#155 

### 🙏 여기는 꼭 봐주세요!


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **스타일**
  * 이메일 인증 완료 화면의 레이아웃 정렬을 반응형으로 개선하여 데스크톱에서 중앙 정렬로 표시되도록 조정했습니다.
  * 학생 인증 확인 페이지의 헤더/텍스트 정렬을 반응형으로 개선해 다양한 화면 크기에서 콘텐츠 위치 일관성을 향상시켰습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->